### PR TITLE
add logout function for admin and fix headers for admin

### DIFF
--- a/app/Http/Controllers/Admin/AdminLoginController.php
+++ b/app/Http/Controllers/Admin/AdminLoginController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Illuminate\Http\Request;
+
 
 class AdminLoginController extends Controller
 {
@@ -30,5 +32,15 @@ class AdminLoginController extends Controller
         return back()->withErrors([
             'login' => ['ログインに失敗しました'],
         ]);
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/admin/login');
     }
 }

--- a/app/Http/Controllers/Auth/Admin/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/Admin/AuthenticatedSessionController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Auth\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use App\Models\Admin;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+use Illuminate\Validation\Rules;
+use Illuminate\Support\Facades\Hash;
+
+
+class AuthenticatedSessionController extends Controller
+{
+
+    public function create(): View
+    {
+        return view('admin.auth.register');
+    }
+
+    // 登録実行
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'last_name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:' . Admin::class],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $admin = Admin::create([
+            'last_name' => $request->last_name,
+            'first_name' => $request->first_name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        event(new Registered($admin));
+
+        Auth::guard('admin')->login($admin);
+
+        return redirect()->route('admin.dashboard')->with([
+            'login_msg' => 'ログインしました。',
+        ]);
+    }
+
+    // ログイン画面呼び出し
+    public function showLoginPage(): View
+    {
+        return view('admin.auth.login');
+    }
+
+    // ログイン実行
+    public function login(LoginRequest $request): RedirectResponse
+    {
+        $credentials = $request->only(['email', 'password']);
+
+        if (Auth::guard('admin')->attempt($credentials)) {
+            return redirect()->route('admin.daily')->with([
+                'login_msg' => 'ログインしました。',
+            ]);
+        }
+
+        return back()->withErrors([
+            'login' => ['ログインに失敗しました'],
+        ]);
+    }
+
+
+    /**
+     * Destroy an authenticated session.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/admin/login');
+    }
+}

--- a/resources/views/admin/attendances/admins.blade.php
+++ b/resources/views/admin/attendances/admins.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
             <!-- テーブルのグループ -->
             <div class="timecard-title">

--- a/resources/views/admin/attendances/adminscreate.blade.php
+++ b/resources/views/admin/attendances/adminscreate.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/adminsedit.blade.php
+++ b/resources/views/admin/attendances/adminsedit.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/admintimecard.blade.php
+++ b/resources/views/admin/attendances/admintimecard.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/counselorcreate.blade.php
+++ b/resources/views/admin/attendances/counselorcreate.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/counselors.blade.php
+++ b/resources/views/admin/attendances/counselors.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
             <!-- テーブルのグループ -->
             <div class="timecard-title">

--- a/resources/views/admin/attendances/counselorsedit.blade.php
+++ b/resources/views/admin/attendances/counselorsedit.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/daily.blade.php
+++ b/resources/views/admin/attendances/daily.blade.php
@@ -9,14 +9,14 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->
             <div class="timecard-title">
                 <p>日別出勤状況</p>
             </div>
-            <div class="timecard-selectors">
+            <div class="timecard-selectors">s
                 <input type="date" name="date" value="{{ $selectedDate }}" id="dateInput">
             </div>
             @if ($errors->any())

--- a/resources/views/admin/attendances/exportshow.blade.php
+++ b/resources/views/admin/attendances/exportshow.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/residencecreate.blade.php
+++ b/resources/views/admin/attendances/residencecreate.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/residences.blade.php
+++ b/resources/views/admin/attendances/residences.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
             <!-- テーブルのグループ -->
             <div class="timecard-title">

--- a/resources/views/admin/attendances/residencesedit.blade.php
+++ b/resources/views/admin/attendances/residencesedit.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/users.blade.php
+++ b/resources/views/admin/attendances/users.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
             <!-- テーブルのグループ -->
             <div class="timecard-title">

--- a/resources/views/admin/attendances/userscreate.blade.php
+++ b/resources/views/admin/attendances/userscreate.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/usersedit.blade.php
+++ b/resources/views/admin/attendances/usersedit.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/workschedule.blade.php
+++ b/resources/views/admin/attendances/workschedule.blade.php
@@ -9,7 +9,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/admin/attendances/workschedulecreate.blade.php
+++ b/resources/views/admin/attendances/workschedulecreate.blade.php
@@ -10,7 +10,7 @@
         <!-- メインコンテンツのカラム -->
         <div class="col-md-10">
             {{-- ヘッダー --}}
-            @include('components.header')
+            @include('components.header-admin')
 
 
             <!-- テーブルのグループ -->

--- a/resources/views/components/header-admin.blade.php
+++ b/resources/views/components/header-admin.blade.php
@@ -1,0 +1,25 @@
+<!-- ユーザー情報とログアウトボタン -->
+<div class="user-header bg-light py-3">
+    <div class="d-flex justify-content-end align-items-center px-4">
+        <!-- ユーザー名とアイコンのドロップダウン -->
+        <div class="dropdown">
+            <a href="#" class="dropdown-toggle d-flex align-items-center text-decoration-none"
+                data-bs-toggle="dropdown">
+                {{-- <i class="bi bi-person-circle me-2" style="color: gray;"></i> --}}
+                <span
+                    class="font-medium text-base text-dark">{{ Auth::user()->last_name . ' ' . Auth::user()->first_name }}</span>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end">
+                <!-- ログアウトボタン -->
+                <li>
+                    <form method="POST" action="{{ route('admin.destroy') }}">
+                        @csrf
+                        <button type="submit" class="dropdown-item">
+                            ログアウト
+                        </button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,7 @@ Route::group(['prefix' => 'admin'], function () {
         ->name('admin.login');
 
     Route::post('login', [AdminLoginController::class, 'login']);
+    Route::post('logout', [AdminLoginController::class, 'destroy'])->name('admin.destroy');
 
     // 以下の中は認証必須のエンドポイントとなる
     Route::middleware(['auth:admin'])->group(function () {


### PR DESCRIPTION
Context
During manual testing of the feature, I noticed issues with the admin user logout functionality:

1.  When pressing the logout button, admin users are redirected to the normal user's login page instead of the admin user's login page. This redirection is not appropriate for admin users.
 2.  After logging out, the session remains active, allowing access to admin/timecard, a page that should not be accessible by guest users.

Problem
Admin users are unable to log out due to the absence of a logout function.
The admin pages require a distinct header view which is currently not implemented.

Solution
Implemented a logout function for admin users to securely end their sessions.
Created a new header view specifically for admin pages to ensure a consistent user experience and easy navigation.

Changes Made
Added a logout method in the AdminLoginController.
Developed a new header view for admin pages and integrated it with existing admin views.

Testing Done
Manual testing to confirm that the logout functionality works as expected for admin users.
Verified that the new admin header appears correctly across all admin pages without affecting other functionalities.
