### PR TITLE
Feature: Implement Store leave function in Timecard page

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -182,8 +182,15 @@ class AttendanceController extends Controller
         $userDetail = $user->userDetail;
 
         $attendance->company_id = $userDetail->company_id;
-        $attendance->attendance_type_id = 1;
         $attendance->check_in_time = Carbon::now()->toTimeString();
+
+        //10時以降のcheck-in→遅刻 basetimeを設定
+        $baseCheckInTime = Carbon::parse('10:00:00');
+        if (Carbon::now()->gt($baseCheckInTime)) {
+            $attendance->attendance_type_id = 2;
+        } else {
+            $attendance->attendance_type_id = 1;
+        }
 
         //work_schedulesからdateidを取得
         $today = Carbon::today();

--- a/database/migrations/2024_03_11_151458_make_check_in_time_nullable_on_attendance_table.php
+++ b/database/migrations/2024_03_11_151458_make_check_in_time_nullable_on_attendance_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attendances', function (Blueprint $table) {
+            // check_in_timeカラムをNULL許容に変更
+            $table->time('check_in_time')->nullable()->change();
+            $table->decimal('body_temp', 5, 2)->nullable()->change();;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attendances', function (Blueprint $table) {
+            //
+            // check_in_timeカラムをNULL不許容に戻す
+            $table->time('check_in_time')->nullable(false)->change();
+            $table->decimal('body_temp', 5, 2)->nullable(false)->change();;
+        });
+    }
+};

--- a/database/seeders/AttendanceTypeSeeder.php
+++ b/database/seeders/AttendanceTypeSeeder.php
@@ -20,6 +20,8 @@ class AttendanceTypeSeeder extends Seeder
         ], [
             'name' => '欠勤',
         ], [
+            'name' => '無断欠勤',
+        ], [
             'name' => '有給',
         ]];
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -211,6 +211,30 @@
     line-height: normal !important;
 }
 
+.btn-edit {
+    border-radius: 3px !important;
+    border: 0.5px solid #C1C1C1 !important;
+    background: #F8F8F8 !important;
+    color: #4874B4 !important;
+    font-family: Roboto !important;
+    font-size: 9px !important;
+    font-style: normal !important;
+    font-weight: 700 !important;
+    line-height: normal !important;
+}
+
+.btn-store-leave {
+    border-radius: 3px !important;
+    border: 0.5px solid #C1C1C1 !important;
+    background: #F8F8F8 !important;
+    color: red !important;
+    font-family: Roboto !important;
+    font-size: 9px !important;
+    font-style: normal !important;
+    font-weight: 700 !important;
+    line-height: normal !important;
+}
+
 .btn-create {
     border-radius: 4px !important;
     background: #D0A307 !important;
@@ -244,6 +268,10 @@
 .error {
 
     color: red;
+}
+
+.select2-container--default .select2-results__option {
+    color: red; /* オプションの文字色を赤にする */
 }
 
 /* 

--- a/resources/views/admin/attendances/admintimecard.blade.php
+++ b/resources/views/admin/attendances/admintimecard.blade.php
@@ -25,7 +25,7 @@
                     <div class="col-sm-2">
                         <div class="form-group mb-2 mr-sm-2">
                             <p class="mb-4">利用者名</p>
-                            <select class="form-control" id="userInput" name="user">
+                            <select class="form-control" id="userInput" name="user" style="color:red">
                                 @foreach ($users as $user)
                                     <option value="{{ $user['id'] }}" {{ $user['id'] == $user_id ? 'selected' : '' }}>
                                         {{ $user->full_name }}</option>
@@ -41,6 +41,7 @@
                         <tr>
                             <th scope="col">日付</th>
                             <th scope="col">勤務日種別</th>
+                            <th scope="col">勤怠種別</th>
                             <th scope="col">体温</th>
                             <th scope="col">出勤時間</th>
                             <th scope="col">退勤時間</th>
@@ -60,6 +61,7 @@
                                 <tr>
                                     <td>{{ $date['date'] }}</td>
                                     <td>{{ $date['scheduleType'] }}</td>
+                                    <td>{{ $date['attendance_type'] }}</td>
                                     <td>{{ $date['bodyTemp'] }}</td>
                                     <td>{{ $date['checkin'] }}</td>
                                     <td>{{ $date['checkout'] }}</td>
@@ -71,6 +73,70 @@
                                     <td>{{ $date['workComment'] }}</td>
                                     <td>{!! $date['admin_comment'] !!}</td>
                                     @if (!$date['attendance_id'])
+                                        @if ($date['scheduleType'] == $date['workday_name'])
+                                            <td>
+                                                <!-- 欠勤登録ボタン -->
+                                                <button type="button" class="btn btn-store-leave store-leave"
+                                                    id="{{ $date['workSchedule_id'] }}">
+                                                    欠勤
+                                                </button>
+                                                <!-- 欠勤登録モーダル -->
+                                                <div class="modal fade" id="leaveModal-{{ $date['workSchedule_id'] }}"
+                                                    tabindex="-1" aria-labelledby="leaveModalLabel" aria-hidden="true">
+                                                    <div class="modal-dialog">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header modal-header-no-border">
+                                                                <button type="button" class="btn-close"
+                                                                    data-bs-dismiss="modal" aria-label="Close"></button>
+                                                            </div>
+                                                            <div class="modal-body">
+                                                                <h5 class="modal-title modal-title-centered"
+                                                                    id="leaveModalLabel">
+                                                                    欠勤データ登録
+                                                                </h5>
+                                                                {{-- form in modal --}}
+                                                                <form id="attendance-form"
+                                                                    action="{{ route('admin.store.leave', ['user_id' => $user_id, 'sched_id' => $date['workSchedule_id']]) }}"
+                                                                    method="post">
+                                                                    @csrf
+                                                                    <div class="mb-3">
+                                                                        <input type="hidden" name="yearmonth"
+                                                                            value="{{ $year . '-' . $month }}">
+                                                                        <label class="mb-2">出欠種別</label><br>
+                                                                        @foreach ($leaveTypes as $leaveType)
+                                                                            <input type="radio"
+                                                                                id="leave_radio_{{ $leaveType->id }}{{ $date['workSchedule_id'] }}"
+                                                                                name="leave_type_id"
+                                                                                value='{{ $leaveType->id }}',required
+                                                                                @if ($loop->first) checked @endif>
+                                                                            <label class="me-2"
+                                                                                for="leave_radio_{{ $leaveType->id }}{{ $date['workSchedule_id'] }}">
+                                                                                {{ $leaveType->name }}</label>
+                                                                        @endforeach
+                                                                    </div>
+                                                                    <div class="mb-3">
+                                                                        <label for="admin_description"
+                                                                            class="modal-label">内容</label>
+                                                                        <textarea class="form-control" id="admin_description" name="admin_description" required></textarea>
+                                                                    </div>
+                                                                    <div class="mb-3">
+                                                                        <label for="admin_comment"
+                                                                            class="modal-label">コメント</label>
+                                                                        <textarea class="form-control" id="admin_comment" name="admin_comment" required></textarea>
+                                                                    </div>
+                                                                    <div
+                                                                        class="modal-footer modal-footer-no-border d-flex justify-content-center">
+                                                                        <button type="submit"
+                                                                            class="btn btn-modal-attend">欠勤登録する</button>
+                                                                    </div>
+                                                                </form>
+                                                                {{-- form in modal --}}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        @endif
                                         <td></td>
                                     @else
                                         <td>
@@ -91,4 +157,22 @@
     </div>
 
     <script src="{{ asset('js/calendar/monthUserChangeHandler.js') }}"></script>
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const leaveButtons = document.querySelectorAll('.store-leave'); // 退勤ボタンのID
+            leaveButtons.forEach(function(button) {
+                const curId = button.id
+                const curLeaveModal = new bootstrap.Modal(document.getElementById(`leaveModal-${curId}`));
+                console.log(curLeaveModal)
+
+                button.addEventListener('click', function() {
+                    console.log('clicked');
+                    curLeaveModal.show();
+                });
+            });
+        });
+    </script>
+
 @endsection

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="{{ asset('css/style.css') }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.min.css"
@@ -13,6 +12,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <link rel="stylesheet" href="{{ asset('css/style.css') }}">
     <title>@yield('title')</title>
 </head>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,6 +117,7 @@ Route::group(['prefix' => 'admin'], function () {
         Route::post('export', [AdminAttendanceController::class, 'export'])->name('admin.export');
         Route::get('attendance/{id}/edit', [AdminAttendanceController::class, 'editAttendance'])->name('admin.attendance.edit');
         Route::patch('attendance/{id}/update', [AdminAttendanceController::class, 'updateAttendance'])->name('admin.attendance.update');
+        Route::post('attendance/store/leave/{user_id}/{sched_id}', [AdminAttendanceController::class, 'storeLeave'])->name('admin.store.leave');
     });
 });
 


### PR DESCRIPTION
Context
During feature evaluation, it became apparent that there is a need to accommodate attendance records for users on leave. Leave types include Paid Leave, Absence without Notice, and Absence with Notice. Additionally, it is essential for admin users to be able to add comments for each leave entry.

Problem
Currently, there is no functionality to record leave data for users.

Solution
Implemented an "Add Absence" button on the admin's timecard page to facilitate the entry of leave data.
Changes Made
Introduced an "Add Absence" button for users lacking attendance data on working days.
Implemented a modal pop-up for the entry of absence data.
Added a storeLeave method in AdminAttendanceController to handle the storage of leave records.
Testing Done
Conducted manual testing to ensure that absence data is accurately recorded and stored as intended.
